### PR TITLE
feat: Set buildpack details when in jx-requirements

### DIFF
--- a/env/jxboot-resources/values.tmpl.yaml
+++ b/env/jxboot-resources/values.tmpl.yaml
@@ -70,6 +70,11 @@ gitops:
     dockerRegistryOrg: ""
 {{- end }}
 
+{{- if hasKey .Requirements "buildPacks" }}
+    buildPackName: "{{ .Requirements.buildPacks.buildPackLibrary.name }}"
+    buildPackUrl: "{{ .Requirements.buildPacks.buildPackLibrary.gitURL }}"
+    buildPackRef: "{{ .Requirements.buildPacks.buildPackLibrary.gitRef }}"
+{{- end }}
 
   staging:
     repo: "{{ .Environments.staging.repository }}"


### PR DESCRIPTION
Follows on from the work done in [1]. If a user provides a custom
buildpack in their requirements file, we use that here. Which overrides
the default buildpack.

1.) https://github.com/jenkins-x/jx/pull/7172